### PR TITLE
Genius: remove translations header

### DIFF
--- a/src/ts/lyricsModules/genius.ts
+++ b/src/ts/lyricsModules/genius.ts
@@ -36,10 +36,21 @@ function parseAlt(dom: Document): string {
     for (const element of classes) {
         try {
             if (element.className.includes("Lyrics__Container-sc-")) {
+
+                // Remove header
+                if (element.innerHTML.includes("LyricsHeader__Container-sc")) {
+                    const header = element.querySelector("[class^='LyricsHeader__Container-sc']");
+                    if (header) {
+                        element.removeChild(header);
+                    }
+                }
+
                 // Convert <br> explicitly, otherwise it will just
                 // get consumed later without adding a new line.
+                
                 lyrics += element.innerHTML.replaceAll("<br>", "\n");
             }
+            
         }
         catch {
             continue;


### PR DESCRIPTION
Removes the header used on genius for translations.

Before:
<img width="359" height="57" alt="imagen" src="https://github.com/user-attachments/assets/d6b3744b-6189-4474-b688-e9abd4538244" />

After:

<img width="202" height="33" alt="imagen" src="https://github.com/user-attachments/assets/890120de-aaca-43dc-8029-dca1d23e130d" />
